### PR TITLE
Don’t add the project sub-path to PATH.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/base.py
@@ -8,18 +8,13 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.7/ref/settings/
 """
 
-from os.path import abspath, basename, dirname, join, normpath
-from sys import path
+from os.path import abspath, dirname, join, normpath
 
 # Absolute filesystem path to the Django project directory:
 DJANGO_ROOT = dirname(dirname(abspath(__file__)))
 
 # Absolute filesystem path to the top-level project folder:
 PROJECT_ROOT = dirname(DJANGO_ROOT)
-
-# Add our project to our pythonpath, this way we don't need to type our project
-# name in our dotted import paths:
-path.append(DJANGO_ROOT)
 
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION
As we faced in a Torchbox internal project, this confuses Django’s model registry.
If you try to import, for example,  the model `home.HomePage` using `from home import HomePage`,
 you’ll get an error since he already found the same model in `{{cookiecutter.repo_name}}.home.HomePage`.

 The exact error is:
 `RuntimeError: Conflicting 'homepage' models in application 'home': <class '{{cookiecutter.repo_name}}.home.models.HomePage'> and <class 'home.models.HomePage'>`