### PR TITLE
Clean up class name on homepage

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/home/templates/home/home_page.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/home/templates/home/home_page.html
@@ -2,7 +2,7 @@
 
 {% load static {% endraw %}{{ cookiecutter.repo_name }}{% raw %}_utils %}
 
-{% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}
+{% block body_class %}template-homepage{% endblock %}
 
 {% block content %}
     <h1>Welcome to your new Wagtail site!</h1>


### PR DESCRIPTION
I think it looks better like this. You don't need to figure out what ``{{ self.get_verbose_name|slugify }}`` resolves to at run time.